### PR TITLE
fix: Added a delay after firebase project creation to allow for project provisioning before integrating it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Flutter Project Setup CLI Changelog
 ### Added
 - Added tests for the create command
 - Added tests for mason brick generations
+- Added a delay after firebase project creation to allow for project provisioning before integrating it
 
 ## 0.0.1
 

--- a/lib/src/commands/create/utils/firebase_setup.dart
+++ b/lib/src/commands/create/utils/firebase_setup.dart
@@ -128,6 +128,9 @@ class FirebaseConfig {
         return false;
       }
 
+      // Wait for a short time to allow for project provisioning
+      await Future.delayed(Duration(seconds: 10));
+
       // Continuously check for the created firebase project
       const maxRetries = 10;
       var attempt = 1;

--- a/lib/src/commands/create/utils/firebase_setup.dart
+++ b/lib/src/commands/create/utils/firebase_setup.dart
@@ -129,7 +129,7 @@ class FirebaseConfig {
       }
 
       // Wait for a short time to allow for project provisioning
-      await Future.delayed(Duration(seconds: 10));
+      await Future<void>.delayed(const Duration(seconds: 10));
 
       // Continuously check for the created firebase project
       const maxRetries = 10;


### PR DESCRIPTION

## Description

Added a delay after firebase project creation to allow for project provisioning before integrating it

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
